### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 #classes
-StepperMotor    KEYWORD1
+StepperMotor	KEYWORD1
 StepperSync	KEYWORD1
 Stepper	KEYWORD1
 
@@ -19,7 +19,7 @@ rotateToSteps	KEYWORD2
 
 move	KEYWORD2
 step	KEYWORD2
-torqueOff   KEYWORD2
+torqueOff	KEYWORD2
 
 #functions from StepperSync
 add	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords